### PR TITLE
Immediately update the 'connected?' status so the view changes quickly

### DIFF
--- a/src/cljs/remote_manager/controller.cljs
+++ b/src/cljs/remote_manager/controller.cljs
@@ -103,7 +103,7 @@
 
 (defn disconnect!
   []
-  (swap! store/state assoc {:connected? false})
+  (swap! store/state assoc-in [:connection :connected?] false)
   (utils/clear-interval "update-services")
   (server-interop/cleanup! server-interop/ssh-disconnect!)
   (swap! store/state update :connection

--- a/src/cljs/remote_manager/controller.cljs
+++ b/src/cljs/remote_manager/controller.cljs
@@ -103,11 +103,11 @@
 
 (defn disconnect!
   []
+  (swap! store/state assoc {:connected? false})
   (utils/clear-interval "update-services")
   (server-interop/cleanup! server-interop/ssh-disconnect!)
   (swap! store/state update :connection
-         #(merge %1 {:connected? false
-                     :connection-pending? false
+         #(merge %1 {:connection-pending? false
                      :error nil})))
 
 (defn launch-mk!


### PR DESCRIPTION
@wmedrano, Can we fail to disconnect? If not, I think it make sense to quickly update the connected status so the view changes immediately after clicking disconnect.
