### PR TITLE
Handle bad inis

### DIFF
--- a/src/cljs/ini_editor/controller.cljs
+++ b/src/cljs/ini_editor/controller.cljs
@@ -11,10 +11,18 @@
 
 ;; topbar
 
+(defn- gen-unique
+  [ids id]
+  (loop [id id]
+    (if (contains? ids id)
+      (recur (update id 1 #(str "copy-" %1)))
+      id)))
+
 (defn- --load-str
   [state id s]
   (try
-    (let [ini (parser/parse-ini s)
+    (let [id (gen-unique (-> state :inis keys set) id)
+          ini (parser/parse-ini s)
           s-metas (:section-metadata ini)
           is-important? #(not (get %1 :unimportant false))
           imp (filter #(-> %1 second is-important?)

--- a/src/cljs/ini_editor/controller.cljs
+++ b/src/cljs/ini_editor/controller.cljs
@@ -13,16 +13,19 @@
 
 (defn- --load-str
   [state id s]
-  (let [ini (parser/parse-ini s)
-        s-metas (:section-metadata ini)
-        is-important? #(not (get %1 :unimportant false))
-        imp (filter #(-> %1 second is-important?)
-                    s-metas)
-        imp-set (set (map first imp))]
-    (-> state
-        (assoc-in [:inis id :ini] ini)
-        (assoc-in [:inis id :expanded?] imp-set)
-        (assoc :selected-ini-id id))))
+  (try
+    (let [ini (parser/parse-ini s)
+          s-metas (:section-metadata ini)
+          is-important? #(not (get %1 :unimportant false))
+          imp (filter #(-> %1 second is-important?)
+                      s-metas)
+          imp-set (set (map first imp))]
+      (-> state
+          (assoc-in [:inis id :ini] ini)
+          (assoc-in [:inis id :expanded?] imp-set)
+          (assoc :selected-ini-id id)))
+    (catch :default e (do (js/alert "Invalid INI")
+                          state))))
 
 (defn load-str!
   "The given ini string representation is loaded for editing. The model is

--- a/src/cljs/text_editor/controller.cljs
+++ b/src/cljs/text_editor/controller.cljs
@@ -9,9 +9,16 @@
 
 ;; loading/saving
 
+(defn- gen-unique
+  [ids id]
+  (loop [id id]
+    (if (contains? ids id)
+      (recur (update id 1 #(str "copy-" %1)))
+      id)))
+
 (defn- --load-text
   [state id text]
-  (let []
+  (let [id (gen-unique (-> state :texts keys set) id)]
     (-> state
         (assoc-in [:texts id] text)
         (assoc :selected-text-id id))))


### PR DESCRIPTION
If a badly formed ini was loaded, the app would throw and stop responding to user input.
Now, an alert shows, and the app resumes as if nothing happened
