### PR TITLE
Closes #12 - Expanded the click area on the drop down

### DIFF
--- a/src/cljs/app/topbar.cljs
+++ b/src/cljs/app/topbar.cljs
@@ -65,76 +65,75 @@
   []
   ((get (current-topbar-actions) "close" identity)))
 
+(defn- topbar-file-open-callback
+  [file-list]
+  (let [file (first file-list)
+        f-id [:local (.-name file)]]
+    (if (some? file)
+      (utils/read-file file #(topbar-action-open f-id %1)))))
+
 (defn topbar-file-menu
   ""
   []
   (let [valid-options (into #{} (keys (current-topbar-actions)))
-        open-el [widgets/file-input {:id "file-input"
-                                     :file-types nil
-                                     :element "Open"
-                                     :on-change (fn [file-list]
-                                                  (let [file (first file-list)
-                                                        f-id [:local (.-name file)]]
-                                                    (if (some? file)
-                                                      (utils/read-file file
-                                                                       #(topbar-action-open f-id
-                                                                                            %1)))))}]
-        download-el [widgets/file-save {:element "Download"
-                                        :filename topbar-action-filename
-                                        :str-func topbar-action-save}]
-        close-el [:a {:key "close"
-                      :on-click topbar-action-close}
-                  "Close"]
-        dropdowns [
-                   (if (contains? valid-options "save") open-el)
+        pointer-style {:cursor "pointer"}
+        open-el  [:li {:key "open"
+                       :style pointer-style
+                       :on-click #(utils/click-element "file-input")}
+                   [:a
+                     [widgets/file-input {:id "file-input"
+                                          :file-types nil
+                                          :element "Open"
+                                          :on-change topbar-file-open-callback}] "Open File"]]
+        save-el  [:li {:key "download"
+                       :style pointer-style
+                       :on-click #(utils/save-file (topbar-action-save) (topbar-action-filename))}
+                   [:a "Download"]]
+        close-el [:li {:key "close"
+                       :style pointer-style
+                       :on-click topbar-action-close}
+                   [:a "Close"]]
+        dropdowns [(if (contains? valid-options "save") open-el)
                    (if (and (contains? valid-options "save")
-                            (contains? valid-options "filename"))
-                     download-el)
-                   (if (contains? valid-options "close")
-                     close-el)
-                   ]
-        should-show? (some some? dropdowns) ; only show if there is a non-nil in dropdowns
-        ]
-    (if should-show?
+                            (contains? valid-options "filename")) save-el)
+                   (if (contains? valid-options "close") close-el)]]
+    ; only show if there is a non-nil in dropdowns
+    (if (some some? dropdowns)
       [navbar/navbar-dropdown {:title "File"
-                               :key "file"
-                               :labels dropdowns}])))
+                                 :list-items dropdowns}])))
 
 (defn topbar-remote-menu
-  ""
+  "Display a dropdown to open and save remote files."
   []
   (let [valid-options (into #{} (keys (current-topbar-actions)))
-        open-el [:span {:key "open"
-                        :on-click #(reset! current-modal "remote-open")} "Open"]
-        upload-el [:span {:key "upload"
-                          :on-click #(reset! current-modal "remote-save")} "Upload"]
-        dropdowns [
-                   (if (contains? valid-options "save") open-el)
+        pointer-style {:cursor "pointer"}
+        open-el   [:li {:key "open"
+                        :style pointer-style
+                        :on-click #(reset! current-modal "remote-open")}
+                    [:a "Open"]]
+        upload-el [:li {:key "upload"
+                        :style pointer-style
+                        :on-click #(reset! current-modal "remote-save")}
+                    [:a "Upload"]]
+        dropdowns [(if (contains? valid-options "open") open-el)
                    (if (and (contains? valid-options "save")
-                            (contains? valid-options "filename"))
-                     upload-el)
-                   ]
-        should-show? (some some? dropdowns) ; only show if there is a non-nil in dropdowns
-        ]
-    (if should-show?
+                            (contains? valid-options "filename")) upload-el)]]
+    ; only show if there is a non-nil in dropdowns
+    (if (some some? dropdowns)
       [navbar/navbar-dropdown {:title "Remote"
-                               :key "remote"
-                               :labels dropdowns}])))
+                                 :list-items dropdowns}])))
 
 (defn topbar-help-menu
-  ""
+  "Display a dropdown for help options."
   []
   (let [valid-options (into #{} (keys (current-topbar-actions)))
-        about-el [:a {:on-click #(reset! current-modal "about-modal")} "About"]
-        dropdowns [
-                   about-el
-                   ]
-        should-show? true ; only show if there is a non-nil in dropdowns
-        ]
-    (if should-show?
-      [navbar/navbar-dropdown {:title "Help"
-                               :key "help"
-                               :labels dropdowns}])))
+        pointer-style {:cursor "pointer"}
+        about-el [:li {:key "about"
+                       :style pointer-style
+                       :on-click #(reset! current-modal "about-modal")}
+                   [:a "About"]]]
+    [navbar/navbar-dropdown {:title "Help"
+                               :list-items [about-el]}]))
 
 
 (defn map-do

--- a/src/cljs/utils/navbar.cljs
+++ b/src/cljs/utils/navbar.cljs
@@ -5,27 +5,16 @@
    [reagent.core :as r :refer [atom]]
    [clojure.string :as string]))
 
-(defn- coerce-to-a
-  "If el is an :a tag, then it remains the same, else it is
-  nexted under an :a tag."
-  [el]
-  (if (and (vector? el) (= (first el) :a))
-    el
-    [:a {:style {:display "flex"}} el]))
-
 (defn navbar-dropdown
   ""
   [props]
-  (let [{:keys [title labels]} props]
+  (let [{:keys [title list-items]} props]
     (assert (string? title))
     [:li.dropdown {:key title}
      [:a.dropdown-toggle {:data-toggle "dropdown"
                           :role "button"
                           :aria-expanded "false"} title [:span.caret]]
-     [:ul.dropdown-menu {:role "menu"}
-      (map (fn [l] [:li {:style {:cursor "pointer"}
-                         :key l} (coerce-to-a l)])
-           labels)]]))
+     [:ul.dropdown-menu {:role "menu"} (lazy-seq list-items)]]))
 
 (defn navbar
   ""

--- a/src/cljs/utils/widgets.cljs
+++ b/src/cljs/utils/widgets.cljs
@@ -85,49 +85,27 @@
     (map #(.item file-list %1) (range len))))
 
 (defn file-input
-  "Renders an element that can be used to query a file from the user.
+  "Returns a tiny/invisible file input component.
   # Props
   `id` - A unique id string. Failure to do so will cause the element to become
   un-clickable.
   `file-types` - Specifies the accepted file types. Use an empty string to
   accept all types.
-  `on-change` - A function that accepts a `list of JavaScript File`.
-  `element` - This component will look exactly like `element`. If no `element`
-  is provided, then a button with the text 'Upload File' will be displayed."
+  `on-change` - A function that accepts a `list of JavaScript File`."
   [props]
-  (let [{:keys [id file-types on-change element]} props]
+  (let [{:keys [id file-types on-change]} props]
     (assert (some? id) "No id was provided")
     (assert (some? on-change) "No on-change was provided.")
-    [:span {:on-click #(utils/click-element id)}
-     (if (some? element) element
-         [:button.btn.btn-default.btn-xs {} "Upload File"])
-     [:input {:id id
-              :style {:height "0px"
-                      :width "0px"
-                      :overflow "hidden"}
-              :value nil
-              :on-change #(-> %1
+    [:input {:id id
+             :type "file"
+             :accept file-types
+             :style {:height "0px" :width "0px"}
+             :value nil
+             :on-change #(-> %1
                               .-target
                               .-files
                               from-file-list
-                              on-change)
-              :type "file"
-              :accept file-types}]]))
-
-(defn file-save
-  "Renders an element that can be used to save a file to disk.
-  # Props
-  `str-func` - Function that returns a string that will be downloaded.
-  `filename` - Function that returns the target filename to be downloaded
-  `element` - This component will look exactly like `element`. Downloading will
-  happen when it is clicked."
-  [props]
-  (let [{:keys [str-func element filename]} props]
-    (assert (fn? str-func))
-    (assert (fn? filename))
-    (assert (some? element))
-    [:span {:on-click #(utils/save-file (str-func) (filename))}
-     element]))
+                              on-change)}]))
 
 (defn list-input
   "Renders an element that can be used to edit a vector of values.


### PR DESCRIPTION
- Click event is on the `li` element instead of the spans inside it
- Refactored the dropdown-menu widget/widget-creator
- Refactored the file-input widget
- Remove the file-save widget (replaced with a lamda call)

@joshcurtis @wmedrano 
