### PR TITLE
Add status to http callbacks

### DIFF
--- a/src/cljs/bbserver/core.cljs
+++ b/src/cljs/bbserver/core.cljs
@@ -15,7 +15,9 @@
              {:keys [status error-code body]} resp
              body (reader/read-string body)]
          ; TODO Modify callbacks to take status + error-code + body
-         (-> resp :body reader/read-string callback))))
+         (callback status error-code body)
+         ; (-> resp :body reader/read-string callback)
+         )))
   ([http-type address callback] (bb-wrapper http-type address callback {})))
 
 (defn- bb-get

--- a/src/cljs/bbserver/core.cljs
+++ b/src/cljs/bbserver/core.cljs
@@ -14,10 +14,7 @@
                                  options))
              {:keys [status error-code body]} resp
              body (reader/read-string body)]
-         ; TODO Modify callbacks to take status + error-code + body
-         (callback status error-code body)
-         ; (-> resp :body reader/read-string callback)
-         )))
+         (callback status error-code body))))
   ([http-type address callback] (bb-wrapper http-type address callback {})))
 
 (defn- bb-get

--- a/src/cljs/bbserver/core.cljs
+++ b/src/cljs/bbserver/core.cljs
@@ -12,8 +12,9 @@
    (go (let [options (merge {:with-credentials? false :timeout 2000} options)
              resp (<! (http-type address
                                  options))
-             {:keys [status body]} resp]
-         ; TODO Modify callbacks to take status + body
+             {:keys [status error-code body]} resp
+             body (reader/read-string body)]
+         ; TODO Modify callbacks to take status + error-code + body
          (-> resp :body reader/read-string callback))))
   ([http-type address callback] (bb-wrapper http-type address callback {})))
 

--- a/src/cljs/remote_manager/controller.cljs
+++ b/src/cljs/remote_manager/controller.cljs
@@ -199,7 +199,7 @@
         (do
           (update-configs!)
           (update-mk-services!))))
-    2000))
+    500))
 
 ; Create an update interval while the user is connected that
 ; updates whether MachineKit is running


### PR DESCRIPTION
- Sends more information about an HTTP request to callbacks
- Addresses #53 an #59 

@wmedrano @joshcurtis 

Things to note:
- Callbacks now take [status error-code body]
- To ignore status and error-code in a lambda, just use `%3` instead of `%` or `%1` 
